### PR TITLE
Ensure redis configuration is actually changed for each instance.

### DIFF
--- a/newrelic_sidekiq_agent
+++ b/newrelic_sidekiq_agent
@@ -27,6 +27,7 @@ module SidekiqStatusAgent
         raise "Redis connection URL missing"
       end
 
+      Sidekiq.instance_variable_set(:@redis, nil)
       Sidekiq.configure_client do |config|
         config.redis = { :url => uri, :namespace => namespace }
       end


### PR DESCRIPTION
The redis connection is memoized as a class-instance variable on `Sidekiq`.
This means that setting the redis configuration has no effect after the first
time within the same process.

You will see this problem if you list more than one instance in the
`config/newrelic_plugin.yml` file where each instance has a different redis
configuration. Although you will see statistics reported in NewRelic for each
instance - the statistics are the same for each. This is because once the redis
configuration has been set it is not changed and all the reported statistics will
come from that redis instance.

It looks as if the NewRelic gem runs all plugins in the same process, so we
need to reset the redis configuration somehow. I can't see a clean way of
doing this with the existing `Sidekiq` API, so this hack will have to do
for now.
